### PR TITLE
Fix Playwright browser launch on headless systems

### DIFF
--- a/tools_browser.py
+++ b/tools_browser.py
@@ -1,15 +1,20 @@
 
 """
 Playwright helpers + JSON schemas that allow the OpenAI agent to drive a
-*single*, visible Chromium tab.  Viewport adapts to the window size so the
-content rescales when the user resizes.
+*single* Chromium tab. The browser is launched in headless mode by default so
+the code can run on servers without a display. Set ``HEADLESS=0`` to launch a
+visible window. Viewport adapts to the window size so the content rescales when
+the user resizes.
 """
 from playwright.sync_api import sync_playwright
 import json
+import os
 
 # ---------- launch ----------
 _pw = sync_playwright().start()
-_browser = _pw.chromium.launch(headless=False)      # visible window
+_headless_env = os.getenv("HEADLESS", "true").lower()
+_headless = _headless_env not in {"0", "false", "no"}
+_browser = _pw.chromium.launch(headless=_headless)
 # viewport=None disables fixed size and lets content follow window resize
 _context = _browser.new_context(viewport=None)
 _page = _context.new_page()


### PR DESCRIPTION
## Summary
- launch Playwright browser in headless mode by default so the app works without an X server
- allow disabling headless mode via `HEADLESS=0`
- update documentation in `tools_browser.py`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m playwright install chromium`
- `python main.py` *(fails: `OpenAIError: The api_key client option must be set ...`)*

------
https://chatgpt.com/codex/tasks/task_e_6852fc0a3b24832a9ff41fcaffbffa7e