### PR TITLE
Fix browser docstring layout

### DIFF
--- a/tools_browser.py
+++ b/tools_browser.py
@@ -1,9 +1,5 @@
 
-"""
-Playwright helpers + JSON schemas that allow the OpenAI agent to drive a
-*single*, visible Chromium tab.  Viewport adapts to the window size so the
-content rescales when the user resizes.
-"""
+"""Playwright helpers + JSON schemas that allow the OpenAI agent to drive a *single*, visible Chromium tab. Viewport adapts to the window size so the content rescales when the user resizes."""
 from playwright.sync_api import sync_playwright
 import json
 


### PR DESCRIPTION
## Summary
- replace multi-line intro with a single-line docstring

## Testing
- `python -m py_compile tools_browser.py`
- `python - <<'PY'
import ast
source=open('tools_browser.py').read()
module=ast.parse(source)
print(ast.get_docstring(module))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6852fd9a4830832aae1857540f31a9e2