### PR TITLE
Rename local run variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def run():
             content=user
         )
 
-        run = client.beta.threads.runs.create(
+        run_obj = client.beta.threads.runs.create(
             thread_id=thread.id,
             assistant_id=assistant.id
         )
@@ -39,7 +39,7 @@ def run():
         while True:
             run_status = client.beta.threads.runs.retrieve(
                 thread_id=thread.id,
-                run_id=run.id
+                run_id=run_obj.id
             )
             if run_status.status == "requires_action":
                 outputs = []
@@ -63,9 +63,9 @@ def run():
                     except Exception as e:
                         result = f"Tool error: {e}"
                     outputs.append({"tool_call_id": tc.id, "output": result})
-                run = client.beta.threads.runs.submit_tool_outputs(
+                run_obj = client.beta.threads.runs.submit_tool_outputs(
                     thread_id=thread.id,
-                    run_id=run.id,
+                    run_id=run_obj.id,
                     tool_outputs=outputs
                 )
             elif run_status.status in {"completed", "failed", "cancelled"}:


### PR DESCRIPTION
## Summary
- rename the variable returned from `threads.runs.create` to `run_obj`
- update subsequent references to use `run_obj.id`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852fd9f8b6c832a9b28ba6203e1d59f